### PR TITLE
Problem: Polished demo requires smaller Main

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -33,263 +33,6 @@ open Megaparsec.Parsec
 
 def main : IO Unit := do
 
-  IO.println "(11) WASM demo coming soon."
-
-  IO.println s!"Digits parse rather efficiently! And now, ergonomically!"
-  let d11 : Digit 'b' := {}
-  IO.println s!"{(d11 : Nat)} == 11" -- We can 'Coe'rce!
-
-  IO.println s!"We have numbers!"
-  let n222 : Option $ Nat' "22_2_2" := mkNat' "22_2_2"
-  let nHd : Option $ Nat' "Herder" := mkNat' "Herder"
-
-  match n222 with
-  | .some sn222 => IO.println s!"{(sn222 : Nat)} == 2222"
-  | .none => IO.println "/_!_\\ BUG IN Nat' \"22\" clause /_!_\\"
-
-  match nHd with
-  | .some _ => IO.println "/_!_\\ BUG IN Nat' \"Herder\" clause /_!_\\"
-  | .none => IO.println s!":thumbs_up:"
-
-  IO.println s!"Let's try signed integers?"
-  let ints := "-50_0"
-  match mkInt' ints with
-  | .some int => IO.println s!"{ints} == {(int : Int)}"
-  | .none => IO.println s!"/_!_\\ BUG IN Int' {ints} clause"
-
-  IO.println "* * *"
-  IO.println "i32.const 42 is represented as:"
-  void $ parseTestP i32P "i32.const 42"
-  IO.println "* * *"
-
-  IO.println "* * *"
-  IO.println "(i32.add (i32.const 42)) is represented as:"
-  void $ parseTestP addP "(i32.add (i32.const 42))"
-  IO.println "* * *"
-
-  IO.println "* * *"
-  let i := "(func)"
-  IO.println s!"{i} is represented as:"
-  void $ parseTestP funcP i
-  IO.println "* * *"
-
-  IO.println "* * *"
-  let i := "param $t i32"
-  IO.println s!"{i} is represented as:"
-  void $ parseTestP paramP i
-  IO.println "* * *"
-
-  IO.println "* * *"
-  let i := "(param $t i32) (param $coocoo i32)"
-  IO.println s!"{i} is represented as:"
-  void $ parseTestP nilParamsP i
-  IO.println "* * *"
-
-  IO.println "* * *"
-  let i := "(param i32) (param $coocoo i32)  ( param i64 ) ( something_else )"
-  IO.println s!"{i} is represented as:"
-  void $ parseTestP nilParamsP i
-  IO.println "* * *"
-
-  IO.println "* * *"
-  let i := "( result i32)"
-  IO.println s!"{i} is represented as:"
-  void $ parseTestP brResultP i
-  IO.println "* * *"
-
-  -- IO.println "* * *"
-  -- let i := "(func (param $x i32) (param $y i32) (result i32)
-  --   (i32.add (local.get $y) (local.get $x))
-  -- )"
-  -- IO.println s!"{i} is represented as:"
-  -- void $ parseTestP funcP i
-  -- IO.println "* * *"
-
-  IO.println "* * *"
-  let i := "(func (param $x i32) (param $y i32) (result i32)
-  )"
-  IO.println s!"{i} is represented as:"
-  void $ parseTestP funcP i
-  IO.println "* * *"
-
-  IO.println "* * *"
-  let i := "(func (param $x i32) (param i32) (result i32))"
-  -- unnamed param should have id 1
-  IO.println s!"{i} is represented as:"
-  void $ parseTestP funcP i
-  IO.println "* * *"
-
-  IO.println "* * *"
-  let i := "(func (param $x i32) (param i32) (result i32) (i32.add (i32.const 40) (i32.const 2)))"
-  -- unnamed param should have id 1
-  IO.println s!"{i} is represented as:"
-  void $ parseTestP funcP i
-  /-
-  (Func.mk
-    none
-    none
-    [ (Local.name (LocalName.mk x (Type'.i (32 : BitSize))))
-    , (Local.index (LocalIndex.mk 1 (Type'.i (32 : BitSize)))) ]
-    (some (Type'.i (32 : BitSize)))
-    []
-    [
-      (Operation.add
-        (Add'.i32
-          (Get.const (Sum.inl (ConstInt (32 : BitSize) 40)) : Get (Type'.i (32 : BitSize)))
-          (Get.const (Sum.inl (ConstInt (32 : BitSize)  2)) : Get (Type'.i (32 : BitSize)))
-        )
-    ]
-  )
-  -/
-  IO.println "* * *"
-
-  IO.println "* * *"
-
-  let i := "(module
-        (func (export \"main\")
-            (result i32)
-
-            (i32.add
-                (i32.const 1499550000)
-                (i32.add (i32.const 9000) (i32.const 17))
-            )
-        )
-    )"
-
-  -- unnamed param should have id 1
-  IO.println s!"{i} is represented as:"
-  let o_parsed_module ← parseTestP moduleP i
-  match o_parsed_module.2 with
-  | .error _ => IO.println "FAIL"
-  | .ok parsed_module => do
-    IO.println s!">>> !!! >>> It is converted to bytes as: {mtob parsed_module}"
-    let f := System.mkFilePath ["/tmp", "special.wasm"]
-    let h ← IO.FS.Handle.mk f IO.FS.Mode.write
-    h.write $ mtob parsed_module
-    IO.println "It's recorded to disk at /tmp/special.wasm"
-
-
-  let i := s!"(module
-        (func (export \"two_ints\")
-            (result i32) (result i32)
-            (i32.add
-                (i32.const 1499550000)
-                (i32.add (i32.const 9000) (i32.const 17))
-            )
-            (i32.add (i32.const -1) (i32.const 1))
-        )
-    )"
-
-  -- unnamed param should have id 1
-  IO.println s!"{i} is represented as:"
-  let o_parsed_module ← parseTestP moduleP i
-  match o_parsed_module.2 with
-  | .error _ => IO.println "FAIL"
-  | .ok parsed_module => do
-    IO.println s!">>> !!! >>> It is converted to bytes as: {mtob parsed_module}"
-    let f := System.mkFilePath ["/tmp", "mtob.59.wasm"]
-    let h ← IO.FS.Handle.mk f IO.FS.Mode.write
-    h.write $ mtob parsed_module
-    IO.println "It's recorded to disk at /tmp/mtob.59.wasm"
-
-  let i := "(module
-        (func (param $x_one i32) (param $three i32) (param $y_one i32) (result i32) (i32.add (i32.const 40) (i32.const 2)))
-        (func (param $x_two i32) (param i32) (param i32) (result i32) (i32.add (i32.const 12) (i32.const 30)))
-  )"
-
-  -- unnamed param should have id 1
-  IO.println s!"{i} is represented as:"
-  let o_parsed_module ← parseTestP moduleP i
-  match o_parsed_module.2 with
-  | .error _ => IO.println "FAIL"
-  | .ok parsed_module => do
-    IO.println s!">>> !!! >>> It is converted to bytes as: {mtob parsed_module}"
-    let f := System.mkFilePath ["/tmp", "mtob.91.wasm"]
-    let h ← IO.FS.Handle.mk f IO.FS.Mode.write
-    h.write $ mtob parsed_module
-    IO.println "It's recorded to disk at /tmp/mtob.91.wasm"
-
-
-  let i := "(module
-    (func (param $x i32) (param i32) (result i32) (i32.add (i32.const 40) (i32.const 2)))
-  )"
-
-  -- unnamed param should have id 1
-  IO.println s!"{i} is represented as:"
-  let o_parsed_module ← parseTestP moduleP i
-  match o_parsed_module.2 with
-  | .error _ => IO.println "FAIL"
-  | .ok parsed_module => do
-    IO.println s!">>> !!! >>> It is converted to bytes as: {mtob parsed_module}"
-    let f := System.mkFilePath ["/tmp", "mtob.47.wasm"]
-    let h ← IO.FS.Handle.mk f IO.FS.Mode.write
-    h.write $ mtob parsed_module
-    IO.println "It's recorded to disk at /tmp/mtob.47.wasm"
-
-  -- NAKED CONST IS NOT IMPLEMENTED YET: https://zulip.yatima.io/#narrow/stream/20-meta/topic/WAST.20pair.20prog/near/32237
-  -- let i := "(module
-  --   (func (param $x i32) (param i32) (result i32) (i32.const 42))
-  -- )"
-  -- -- unnamed param should have id 1
-  -- IO.println s!"{i} is represented as:"
-  -- let o_parsed_module ← parseTestP moduleP i
-  -- match o_parsed_module.2 with
-  -- | .error _ => IO.println "FAIL"
-  -- | .ok parsed_module => do
-  --   IO.println s!">>> !!! >>> It is converted to bytes as: {mtob parsed_module}"
-  --   IO.println "It's recorded to disk at /tmp/mtob.44.wasm"
-  --   let f := System.mkFilePath ["/tmp", "mtob.44.wasm"]
-  --   let h ← IO.FS.Handle.mk f IO.FS.Mode.write
-  --   h.write $ mtob parsed_module
-
-  let i := "(module
-    ( func (param $x i32) (param i32) )
-  )"
-  -- unnamed param should have id 1
-  IO.println s!"{i} is represented as:"
-  let o_parsed_module ← parseTestP moduleP i
-  match o_parsed_module.2 with
-  | .error _ => IO.println "FAIL"
-  | .ok parsed_module => do
-    IO.println s!">>> !!! >>> It is converted to bytes as: {mtob parsed_module}"
-    let f := System.mkFilePath ["/tmp", "mtob.41.wasm"]
-    let h ← IO.FS.Handle.mk f IO.FS.Mode.write
-    h.write $ mtob parsed_module
-    IO.println "It's recorded to disk at /tmp/mtob.41.wasm"
-
-  let i := "(module
-    (func (param $x i32))
-  )"
-  -- unnamed param should have id 1
-  IO.println s!"{i} is represented as:"
-  let o_parsed_module ← parseTestP moduleP i
-  match o_parsed_module.2 with
-  | .error _ => IO.println "FAIL"
-  | .ok parsed_module => do
-    IO.println s!">>> !!! >>> It is converted to bytes as: {mtob parsed_module}"
-    let f := System.mkFilePath ["/tmp", "mtob.40.wasm"]
-    let h ← IO.FS.Handle.mk f IO.FS.Mode.write
-    h.write $ mtob parsed_module
-    IO.println "It's recorded to disk at /tmp/mtob.40.wasm"
-
-  let i := "(module
-    ( func )
-  )"
-  -- unnamed param should have id 1
-  IO.println s!"{i} is represented as:"
-  let o_parsed_module ← parseTestP moduleP i
-  match o_parsed_module.2 with
-  | .error _ => IO.println "FAIL"
-  | .ok parsed_module => do
-    IO.println s!">>> !!! >>> It is converted to bytes as: {mtob parsed_module}"
-    let f := System.mkFilePath ["/tmp", "mtob.24.wasm"]
-    let h ← IO.FS.Handle.mk f IO.FS.Mode.write
-    h.write $ mtob parsed_module
-    IO.println "It's recorded to disk at /tmp/mtob.24.wasm"
-
-  IO.println "* * *"
-
-  -- TODO: pack more ascii into the easter egg with i64
   let i := "(module
     (func $main (export \"main\")
       (param $x i32)
@@ -297,112 +40,32 @@ def main : IO Unit := do
       (result i32)
 
       (i32.add
-        (i32.const 1499550000)
-        (i32.add (i32.const 9000) (i32.const 17))
+        (i32.const 1819606001)
+        (i32.add (i32.const 30000) (i32.const 330))
       )
 
     )
   )"
   -- unnamed param should have id 1
-  IO.println s!"{i} is represented as:"
+  IO.println s!"Module {i} parses to:"
   let o_parsed_module ← parseTestP moduleP i
-  let something_special_module := o_parsed_module -- We'll run it with Engine in a bit
   match o_parsed_module.2 with
-  | .error _ => IO.println "FAIL"
-  | .ok parsed_module => do
-    IO.println s!">>> !!! >>> It is converted to bytes as: {mtob parsed_module}"
-    let f := System.mkFilePath ["/tmp", "something.special.wasm"]
-    let h ← IO.FS.Handle.mk f IO.FS.Mode.write
-    h.write $ mtob parsed_module
-    IO.println "It's recorded to disk at /tmp/something.special.wasm"
-
-  IO.println "* * *"
-
-  -- LEB128 TESTS
-  let lebx := 624485
-  let blebx := ntob lebx
-  /-
-  5> erlang:length( "000010011000011101100101" ).
-  24
-  8> erlang:length("00001001").
-  8
-  9> erlang:length("10000111").
-  8
-  10> erlang:length("01100101").
-  8
-  11> [ 2#00001001, 2#10000111, 2#01100101 ].
-  -/
-  IO.println s!"{blebx} should be [9,135,101]"
-  let bilebx := ByteArray.toBits blebx
-  IO.println s!"{bilebx} should be 000010011000011101100101"
-  let ulebx := unlead bilebx
-  IO.println s!"{ulebx} should be 10011000011101100101"
-  let plebx := pad7 ulebx
-  IO.println s!"{plebx} should be 010011000011101100101"
-  let pp := npad7 lebx
-  IO.println s!"{pp} should be {plebx}"
-  let fin := uLeb128 lebx
-  IO.println s!"{fin} should be 229, 142, 38"
-  IO.println s!"{uLeb128 1} should be 1"
-  -- LE Long
-  --- 00000101 11001011 10000101 11101000 11101001
-  --- becomes in LE:
-  --- 11101001 11101000 10000101 11001011 00000101
-  ---- 233
-  ---- 232
-  ---- 133
-  ---- 203
-  ---- 5
-  let bigN := 1499559017
-  IO.println s!"{uLeb128 bigN} should be 233 232 133 203 5"
-  IO.println s!"{reassemble $ npad7 bigN} should be 00000101 11001011 10000101 11101000 11101001"
-  IO.println s!"= = = = SIGNED LEB128 TEST = = = ="
-  IO.println s!"{sLeb128 (-123456)} should be [192, 187, 120]"
-  IO.println s!"{sLeb128 (1)} should be [1]"
-  IO.println s!"{sLeb128 (624485)} should be 229, 142, 38"
-  /-
-                4> 2#0000001.
-                1
-                5> 2#1111110.
-                126
-                6> 2#1111111.
-                127
-                7> 2#01111111.
-                127
-  -/
-  IO.println s!"{sLeb128 (-1)} should be [127]"
-  IO.println s!"{sLeb128 9000} should be 168, 198, 0 (because it's signed!)"
-  IO.println s!"{uLeb128 9000} should be 70, 168"
-  IO.println s!"{sLeb128 8787} should be 211, 196, 00"
-  IO.println s!"= = END OF SIGNED LEB128 TEST! = ="
-
-
-  match something_special_module.2 with
-  | .error _ => IO.println s!"THERE IS A BUG IN RUNTIME TEST"
+  | .error _ => IO.println s!"Error: There was an error parsing the module"
   | .ok m => do
-    IO.println s!"!!!!!!!!!!!! DEMO OF WASM LEAN RUNTIME WOW !!!!!!!!!!!!!"
-    IO.println s!"RUNNING FUNCTION `main` FROM A MODULE WITH REPRESENTATION:\n{m}"
     let store := mkStore m
     let ofid := fidByName store "main"
     let uni_num_zero := NumUniT.i $ ConstInt.mk 32 0
     let se_zero := StackEntry.num uni_num_zero
     IO.println $ match ofid with
-    | .none => s!"THERE IS NO FUNCTION CALLED `main`"
+    | .none => s!"There is no function named `main`"
     | .some fid =>
       let eres := run store fid $ Stack.mk [se_zero, se_zero]
       match eres with
       | .ok stack2 => match stack2.es with
         | x :: _ => match x with
           | .num universal_number => match universal_number with
-            | .i i => s!"!!!!!!!!!!!!!! SUCCESS !!!!!!!!!!!!!!!!\n{i}"
-        | _ => "UNEXPECTED RESULT"
-      | .error ee => s!"FAILED TO RUN `main` CORRECTLY: {ee}"
-
-  let mut x := 0
-  x := 1
-  IO.println s!"Thanks for using Webassembly with Lean, you're #{x}!"
-  let x1 := 1499559017
-  IO.println s!"BE who you want to be: {x1.toByteArrayBE}..."
-  IO.println s!"LEarn lean for fun and profit: {x1.toByteArrayLE}!"
+            | .i i => s!"And successfully evaluates to: {i}"
+        | _ => "Error: Unexpected stack"
+      | .error ee => s!"Error: Failed to run `main` with {ee}"
 
   pure ()

--- a/Wasm/Demo/Steps.lean
+++ b/Wasm/Demo/Steps.lean
@@ -1,0 +1,31 @@
+import Wasm.Engine
+import Wasm.Wast.Code
+import Wasm.Wast.Num
+import Wasm.Wast.BitSize
+
+import Megaparsec.Parsec
+
+open Wasm.Engine
+open Wasm.Wast.Code
+open Wasm.Wast.Code.Module
+open Wasm.Wast.Num.Uni
+open Wasm.Wast.Num.Num.Int
+
+open Megaparsec.Parsec
+open Func
+open Type'
+open Operation
+
+def run_wasm (m : Module) : Int := Id.run $ do
+  let un₀ := NumUniT.i $ ConstInt.mk 32 0
+  let se₀ := StackEntry.num un₀
+  let store := mkStore m
+  -- Use function #0
+  let eres := run store 0 $ Stack.mk [se₀, se₀]
+  match eres with
+  | .ok σ₂ => match σ₂.es with
+    | x :: _ => match x with
+      | .num un => match un with
+        | .i i => i.val
+    | _ => (-4 : Int)
+  | _ => (-5 : Int)

--- a/Wasm/Wast/BitSize.lean
+++ b/Wasm/Wast/BitSize.lean
@@ -3,10 +3,14 @@ import Megaparsec.Char
 import Megaparsec.Common
 import Megaparsec.Parsec
 
+import Printiest.Doc
+
 open Megaparsec
 open Megaparsec.Char
 open Megaparsec.Common
 open Megaparsec.Parsec
+
+open Doc
 
 
 /- Webassembly works on 32 and 64 bit ints and floats.
@@ -68,6 +72,15 @@ instance : Ord BitSize where
 /- We rely on numeric ordering rather than on derived ordering based on the order of constructors. -/
 instance : Ord BitSizeSIMD where
   compare x y := Ord.compare (x : Nat) (y : Nat)
+
+def BitSize.pretty (bs : BitSize) : Doc :=
+  -- let inner := match bs with
+  -- | .thirtyTwo => Doc.group #[Doc.Text "32",  ":", "BitSize"] " "
+  -- | .sixtyFour => Doc.group #[Doc.Text "64",  ":", "BitSize"] " "
+  let inner := match bs with
+  | .thirtyTwo => "32 : BitSize"
+  | .sixtyFour => "64 : BitSize"
+  "(" <> inner <> ")"
 
 instance : ToString BitSize where
   toString x := "(" ++ toString (x : Nat) ++ " : BitSize)"

--- a/Wasm/Wast/Num.lean
+++ b/Wasm/Wast/Num.lean
@@ -3,6 +3,8 @@ import Wasm.Wast.Radix
 import Wasm.Wast.Sign
 import Wasm.Wast.Parser.Common
 
+import Printiest.Doc
+
 import Megaparsec.Common
 import Megaparsec.Errors
 import Megaparsec.Errors.Bundle
@@ -11,6 +13,8 @@ import Megaparsec.MonadParsec
 import YatimaStdLib.NonEmpty
 
 open Wasm.Wast.Parser.Common
+
+open Doc
 
 open Megaparsec
 open Megaparsec.Common
@@ -266,6 +270,10 @@ structure ConstInt where
   bs : BitSize
   val : Int
   deriving BEq
+
+def ConstInt.pretty (x : ConstInt) : Doc :=
+    let inner := Doc.group #[ "ConstInt.mk", x.bs.pretty, s!"{x.val}" ] " "
+    "(" <> inner <> ")"
 
 instance : ToString ConstInt where
   toString x := "(ConstInt.mk " ++ toString x.bs ++ " " ++ toString x.val ++ ")"

--- a/Yati32Raw.lean
+++ b/Yati32Raw.lean
@@ -1,53 +1,18 @@
-import Wasm.Engine
-import Wasm.Wast.Code
+import Wasm.Demo.Steps
 import Wasm.Wast.Num
-import Wasm.Wast.BitSize
+import Wasm.Wast.Code
 
-import Megaparsec.Parsec
-
-open Wasm.Engine
 open Wasm.Wast.Code
 open Wasm.Wast.Code.Module
-open Wasm.Wast.Num.Uni
+open Wasm.Wast.Code.Func
+open Wasm.Wast.Code.Local
+open Wasm.Wast.Code.Type'
+open Wasm.Wast.Code.Operation
 open Wasm.Wast.Num.Num.Int
 
-open Megaparsec.Parsec
-open Func
-open Type'
-open Operation
 
-def go : Int := Id.run $ do
-  let un₀ := NumUniT.i $ ConstInt.mk 32 0
-  let se₀ := StackEntry.num un₀
-
-  let yati32_mod ← (
-    Module.mk none
-    [
-      (Func.mk none
-               (some "main")
-               []
-               [(Type'.i (32 : BitSize))]
-               []
-               [
-                  (Operation.add (Add'.add (Type'.i (32 : BitSize))
-                                 (Get'.i_const (ConstInt.mk (32 : BitSize) 1499550000))
-                                 (Get'.from_operation
-                                    (Operation.add (Add'.add (Type'.i (32 : BitSize))
-                                                   (Get'.i_const (ConstInt.mk (32 : BitSize) 9000))
-                                                   (Get'.i_const (ConstInt.mk (32 : BitSize) 17)))))))])])
-  let store := mkStore yati32_mod
-  let ofid := Option.some 0
-  match ofid with
-  | .none => (-2 : Int)
-  | .some fid =>
-    let eres := run store fid $ Stack.mk [se₀, se₀]
-    match eres with
-    | .ok σ₂ => match σ₂.es with
-      | x :: _ => match x with
-        | .num un => match un with
-          | .i i => i.val
-      | _ => (-4 : Int)
-    | _ => (-5 : Int)
+def run : Int := Id.run $ do
+  run_wasm (Module.mk none [(Func.mk (some "main") (some "main") [(Local.mk 0 (some "x") (Type'.i (32 : BitSize))), (Local.mk 1 none (Type'.i (32 : BitSize)))] [(Type'.i (32 : BitSize))] [] [(Operation.add (Add'.add (Type'.i (32 : BitSize)) (Get'.i_const (ConstInt.mk (32 : BitSize) 1819606001)) (Get'.from_operation (Operation.add (Add'.add (Type'.i (32 : BitSize)) (Get'.i_const (ConstInt.mk (32 : BitSize) 30000)) (Get'.i_const (ConstInt.mk (32 : BitSize) 330)))))))])])
 
 def main : IO Unit := do
-  IO.println go
+  IO.println run

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -20,6 +20,9 @@ require Megaparsec from git
 require Yatima from git
   "https://github.com/yatima-inc/yatima-lang" @ "e604a1178942b68ef0c1c9b11ea9b74ddf1943e0"
 
+require Printiest from git
+  "https://github.com/yatima-inc/printiest" @ "15ad9af7cd9b57b6ab948942a14f7900f473ff41"
+
 @[default_target]
 lean_exe wasm {
   supportInterpreter := true


### PR DESCRIPTION
Solution:

 - To have less noise in Yati32Raw, move run_wasm : Module -> Int that runs wasm modules of type i32 -> i32. - The reason why we use i32 -> i32 underlying runs is because we can branch on the i32 argument to: - Test that non-empty initial stacks work when executed from Lean Wasm sandbox. - Make sure that we can branch based on some initial parameter in tests we run (this capacity isn't actually used in `run_wasm`, we always start with [0]). - The result value of i32 is a good thing to have to be able to tell if the run has succeeded or not.
 - We have made Main smaller and attempted to use printiest.
 - We have failed to make printiest work properly, but an attempt is an attempt.