### PR TITLE
Problem: no executable asset if downloaded in x86 mode

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -71,6 +71,7 @@ function download_sandbox_x86() {
     # Force-download the sandbox.x86 binary
     wget "$sandbox_x86_url" -O wasm-sandbox.new && rm -f wasm-sandbox 2>/dev/null
     mv wasm-sandbox{.new,}
+    chmod +x wasm-sandbox
 }
 
 function download_sandbox_compile() {


### PR DESCRIPTION
Solution:

 - Insert `chmod +x wasm-sandbox` into the download_..._x86 function to make the downloaded asset executable.