### PR TITLE
Support calling other functions

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -70,7 +70,7 @@ def main : IO Unit := do
     IO.println s!"!!!!!!!!!!!! DEMO OF WASM LEAN RUNTIME WOW !!!!!!!!!!!!!"
     IO.println s!"RUNNING FUNCTION `main` FROM A MODULE WITH REPRESENTATION:\n{m}"
     let store := mkStore m
-    let ofid := fidByName store "main"
+    let ofid := exportedFidByName store "main"
     let uni_num_zero := NumUniT.i $ ConstInt.mk 32 0
     let se_zero := StackEntry.StackEntry.num uni_num_zero
     IO.println $ match ofid with

--- a/Tests/BinaryCompatibility.lean
+++ b/Tests/BinaryCompatibility.lean
@@ -254,6 +254,11 @@ def modsControl :=
         (func (result i32) (i32.const 0x132))
         (func (export \"type-i32\") (result i32) (call 0))
      )"
+  , "(module
+        (func (result i32)
+          (block (result i32) (i32.const 1) (return))
+        )
+     )"
   ]
 
 def modsLocal :=

--- a/Tests/BinaryCompatibility.lean
+++ b/Tests/BinaryCompatibility.lean
@@ -246,6 +246,14 @@ def modsControl :=
         )
         (i32.const 22)
      ))"
+  , "(module
+        (func $const-i32 (result i32) (i32.const 0x132))
+        (func (export \"type-i32\") (result i32) (call $const-i32))
+     )"
+  , "(module
+        (func (result i32) (i32.const 0x132))
+        (func (export \"type-i32\") (result i32) (call 0))
+     )"
   ]
 
 def modsLocal :=

--- a/Tests/RuntimeCompatibility.lean
+++ b/Tests/RuntimeCompatibility.lean
@@ -52,6 +52,18 @@ def modsControl :=
         (func $const-i32 (result i32) (i32.const 0x132))
         (func (export \"main\") (result i32) (call $const-i32))
      )"
+  , "(module
+        (func $as-block-value (result i32)
+          (block (result i32) (nop) (i32.const 2) (return) (i32.const 9))
+        )
+        (func (export \"main\") (result i32) (call $as-block-value))
+     )"
+  , "(module
+         (func $midvalues (result i32)
+          (i32.const 20) (nop) (i32.const 2) (return) (i32.const 9)
+        )
+        (func (export \"main\") (result i32) (call $midvalues))
+     )"
   ]
 
 def main : IO UInt32 := do

--- a/Tests/RuntimeCompatibility.lean
+++ b/Tests/RuntimeCompatibility.lean
@@ -46,7 +46,15 @@ def basics :=
      )"
   ]
 
+def modsControl :=
+  [
+    "(module
+        (func $const-i32 (result i32) (i32.const 0x132))
+        (func (export \"main\") (result i32) (call $const-i32))
+     )"
+  ]
+
 def main : IO UInt32 := do
   match (← doesWasmSandboxRun?) with
-  | .ok _ => withWasmSandboxRun runWasmTestSeq [ basics ]
+  | .ok _ => withWasmSandboxRun runWasmTestSeq [ basics, modsControl ]
   | _ => withWasmSandboxFail

--- a/Wasm/Bytes.lean
+++ b/Wasm/Bytes.lean
@@ -553,6 +553,7 @@ mutual
     | .br_table bls bld =>
       b 0x0e ++ mkVecM bls extractBlockLabelId ++ extractBlockLabelId bld
     | .call fi => b 0x10 ++ extractFuncId fi
+    | .return => pure $ b 0x0f
 
 
 end

--- a/Wasm/Bytes.lean
+++ b/Wasm/Bytes.lean
@@ -6,6 +6,7 @@ open Wasm.Leb128
 open Wasm.Wast.Code
 open Wasm.Wast.AST
 open Wasm.Wast.AST.BlockLabel
+open Wasm.Wast.AST.FuncLabel
 open Wasm.Wast.AST.FunctionType
 open Wasm.Wast.AST.Global
 open Wasm.Wast.AST.Local
@@ -70,12 +71,13 @@ def enf (g : ByteArray → ByteArray) (f : α → ByteArray) (x : α) : ByteArra
 def mkStr (x : String) : ByteArray :=
   uLeb128 x.length ++ x.toUTF8
 
+abbrev FuncIds := List (Nat × String)
 abbrev FTypes := List ByteArray
 abbrev Locals := List (Nat × Local)
 abbrev Globals := List (Nat × Global)
 abbrev BlockLabels := List (Option String)
 
-abbrev ExtractM := ReaderT FTypes $ ReaderT Globals $ ReaderT Locals
+abbrev ExtractM := ReaderT FuncIds $ ReaderT FTypes $ ReaderT Globals $ ReaderT Locals
                  $ StateM BlockLabels
 
 def push : Option String → ExtractM PUnit := fun x => do set $ x :: (←get)
@@ -89,6 +91,7 @@ instance : HAppend ByteArray (ExtractM ByteArray) (ExtractM ByteArray) := ⟨eap
 instance : HAppend (ExtractM ByteArray) ByteArray (ExtractM ByteArray) where
   hAppend eb b := eb ++ pure b
 
+def readFIds  : ExtractM FuncIds   := readThe FuncIds
 def readFTypes  : ExtractM FTypes  := readThe FTypes
 def readLocals  : ExtractM Locals  := readThe Locals
 def readGlobals : ExtractM Globals := readThe Globals
@@ -451,6 +454,12 @@ def extractBlockLabelId : BlockLabelId → ExtractM ByteArray
     | .some idx => pure $ sLeb128 idx
     | .none => sorry
 
+def extractFuncId : FuncId → ExtractM ByteArray
+  | .by_index idx => pure $ uLeb128 idx
+  | .by_name name => do match (←readFIds).find? (·.2 = name) with
+    | .some (idx, _) => pure $ sLeb128 idx
+    | .none => sorry
+
 def extractBlockType : FunctionType → ExtractM ByteArray
   | ⟨[],[]⟩ => pure $ b 0x40
   | ⟨[],[t]⟩ => pure $ b (ttoi t)
@@ -543,6 +552,7 @@ mutual
     | .br_if bl => b 0x0d ++ extractBlockLabelId bl
     | .br_table bls bld =>
       b 0x0e ++ mkVecM bls extractBlockLabelId ++ extractBlockLabelId bld
+    | .call fi => b 0x10 ++ extractFuncId fi
 
 
 end
@@ -574,7 +584,8 @@ def extractFuncIds (m : Module) (types : FTypes) : ByteArray :=
     let funcIds := mkVec m.func (uLeb128 ∘ getIndex)
     b 0x03 ++ lindex funcIds
 
-def extractFuncBody (functypes : FTypes) (gls : Globals) (f : Func)
+def extractFuncBody (fids : FuncIds) (functypes : FTypes) (gls : Globals)
+                    (f : Func)
                     : (ByteArray × BlockLabels) :=
   -- Locals are encoded with counts of subgroups of the same type.
   let localGroups := f.locals.groupBy (fun l1 l2 => l1.type = l2.type)
@@ -585,7 +596,7 @@ def extractFuncBody (functypes : FTypes) (gls : Globals) (f : Func)
 
   -- We also return all the previously collected block labels, as we'll
   -- need them in the names section.
-  let (obs, bls) := (extractOps f.ops).run functypes gls (indexIdentifiedLocals f) []
+  let (obs, bls) := (extractOps f.ops).run fids functypes gls (indexIdentifiedLocals f) []
 
   -- for each function's code section, we'll add its size after we do
   -- all the other computations.
@@ -597,7 +608,10 @@ def extractFuncBodies (m : Module) (functypes : FTypes)
                       : (ByteArray × List BlockLabels) :=
   if m.func.isEmpty then (b0, []) else
     let header := b 0x0a
-    let extractFBwGlobals := extractFuncBody functypes $ indexIdentifiedGlobals m.globals
+    let funcIds := m.func.enum.filterMap fun (idx, f) =>
+      if let .some id := f.name then .some (idx, id) else .none
+    let extractFBwGlobals := extractFuncBody funcIds functypes $
+      indexIdentifiedGlobals m.globals
     let (fbs, bls) := List.unzip $ m.func.map extractFBwGlobals
     (header ++ lindex (vectorise fbs), bls)
 

--- a/Wasm/Tests.lean
+++ b/Wasm/Tests.lean
@@ -39,8 +39,8 @@ def run_main (x : String) :=
 def runModule (m : Module) : Except EngineErrors Int := do
   let store := mkStore m
   let s₀ := Stack.mk []
-  match fidByName store "main" with
-  | .none => Except.error EngineErrors.function_not_found
+  match exportedFidByName store "main" with
+  | .none => .error $ .function_not_found (.by_name "main")
   | .some fid =>
     run store fid s₀ >>= fun (_, s₁) =>
       match s₁ with

--- a/Wasm/Wast/AST.lean
+++ b/Wasm/Wast/AST.lean
@@ -86,21 +86,25 @@ instance : ToString BlockLabelId where
   toString | .by_index n => s!"(BlockLabelId.by_index {n})"
            | .by_name ln => s!"(BlockLabelId.by_name {ln})"
 
--- structure LabelIndex where
---   li : Nat
---   deriving Repr, DecidableEq
-
--- instance : Coe Nat LabelIndex where
---   coe n := ⟨n⟩
-
--- instance : Coe LabelIndex Nat where
---   coe | ⟨n⟩ => n
-
--- instance : ToString LabelIndex where
---   toString | ⟨n⟩ => s!"(LabelIndex {n})"
-
 end BlockLabel
 open BlockLabel
+
+namespace FuncLabel
+
+inductive FuncId where
+  | by_index : Nat → FuncId
+  | by_name : String → FuncId
+  deriving Repr, DecidableEq
+
+instance : Coe Nat FuncId where
+  coe n := .by_index n
+
+instance : ToString FuncId where
+  toString | .by_index n => s!"(FuncId.by_index {n})"
+           | .by_name ln => s!"(FuncId.by_name {ln})"
+
+end FuncLabel
+open FuncLabel
 
 structure FunctionType where
   ins  : List Type'
@@ -196,6 +200,7 @@ mutual
   | br : BlockLabelId → Operation
   | br_if : BlockLabelId → Operation
   | br_table : List BlockLabelId → BlockLabelId → Operation
+  | call : FuncId → Operation
 end
 
 mutual
@@ -275,6 +280,7 @@ mutual
     | .br sl => s!"(Operation.br {sl})"
     | .br_if sl => s!"(Operation.br_if {sl})"
     | .br_table sls sdef => s!"(Operation.br_table {sls} {sdef})"
+    | .call fi => s!"(Operation.call {fi})"
 
 end
 

--- a/Wasm/Wast/AST.lean
+++ b/Wasm/Wast/AST.lean
@@ -201,6 +201,7 @@ mutual
   | br_if : BlockLabelId → Operation
   | br_table : List BlockLabelId → BlockLabelId → Operation
   | call : FuncId → Operation
+  | return : Operation
 end
 
 mutual
@@ -281,6 +282,7 @@ mutual
     | .br_if sl => s!"(Operation.br_if {sl})"
     | .br_table sls sdef => s!"(Operation.br_table {sls} {sdef})"
     | .call fi => s!"(Operation.call {fi})"
+    | .return => s!"(Operation.return)"
 
 end
 

--- a/Wasm/Wast/Code.lean
+++ b/Wasm/Wast/Code.lean
@@ -20,8 +20,14 @@ open Wasm.Wast.Parser
 open Wasm.Wast.Parser.Common
 open Wasm.Wast.Num.Num.Int
 open Wasm.Wast.Num.Num.Float
+open Wasm.Wast.Num.Uni
 
 namespace Wasm.Wast.Code
+
+/-- A number's default value is always `0`. -/
+def defNum : Type' → NumUniT
+  | .i bs => .i ⟨bs, 0⟩
+  | .f bs => .f ⟨bs, 0⟩
 
 def replaceNth (xs : List α) (idx : Nat) (x : α) :=
   xs.take idx ++ x :: xs.drop (idx+1)

--- a/Wasm/Wast/Parser.lean
+++ b/Wasm/Wast/Parser.lean
@@ -176,6 +176,9 @@ private def callP : Parsec Char String Unit Operation := do
   let op ← string "call" *> pure .call
   ignoreP *> op <$> funcIdP
 
+private def returnP : Parsec Char String Unit Operation :=
+  string "return" *> pure .return
+
  mutual
 
   partial def getP : Parsec Char String Unit Get' :=
@@ -201,7 +204,7 @@ private def callP : Parsec Char String Unit Operation := do
     iBinopP "shr_u" .shr_u <|> iBinopP "shr_s" .shr_s <|>
     iBinopP "rotl" .rotl <|> iBinopP "rotr" .rotr <|>
     localOpP <|> globalOpP <|>
-    blockOpP <|> ifP <|> brTableP <|> brOpP <|> callP
+    blockOpP <|> ifP <|> brTableP <|> brOpP <|> callP <|> returnP
 
   partial def opsP : Parsec Char String Unit (List Operation) := do
     sepEndBy' opP owP

--- a/Wasm/Wast/Parser.lean
+++ b/Wasm/Wast/Parser.lean
@@ -35,6 +35,7 @@ section textparser
 open Type'
 open Local
 open Global
+open FuncLabel
 open BlockLabel
 open Operation
 open Func
@@ -81,6 +82,10 @@ def localLabelP : Parsec Char String Unit LocalLabel :=
   .by_name <$> idP
 
 def globalLabelP : Parsec Char String Unit GlobalLabel :=
+  .by_index <$> (hexP <|> decimalP) <|>
+  .by_name <$> idP
+
+def funcIdP : Parsec Char String Unit FuncId :=
   .by_index <$> (hexP <|> decimalP) <|>
   .by_name <$> idP
 
@@ -167,6 +172,10 @@ private def brOpP : Parsec Char String Unit Operation := do
        <|> (string "br" *> pure .br)
   ignoreP *> op <$> structLabelP
 
+private def callP : Parsec Char String Unit Operation := do
+  let op ← string "call" *> pure .call
+  ignoreP *> op <$> funcIdP
+
  mutual
 
   partial def getP : Parsec Char String Unit Get' :=
@@ -192,7 +201,7 @@ private def brOpP : Parsec Char String Unit Operation := do
     iBinopP "shr_u" .shr_u <|> iBinopP "shr_s" .shr_s <|>
     iBinopP "rotl" .rotl <|> iBinopP "rotr" .rotr <|>
     localOpP <|> globalOpP <|>
-    blockOpP <|> ifP <|> brTableP <|> brOpP
+    blockOpP <|> ifP <|> brTableP <|> brOpP <|> callP
 
   partial def opsP : Parsec Char String Unit (List Operation) := do
     sepEndBy' opP owP


### PR DESCRIPTION
Problem: we can always run only one single function, but not invoke other functions.

Solution: implemented `call` and `return` by overhauling half the codebase. See individual commits for more description.

NB: while we already had some differences (in opinion) with the WebAssembly spec, this deviates from it even further, including not having activation frames on stack at all. This may or may not spring a trap on us in the future :D