### PR TITLE
Get rid of Get'

### DIFF
--- a/Tests/RuntimeCompatibility.lean
+++ b/Tests/RuntimeCompatibility.lean
@@ -44,6 +44,18 @@ def basics :=
           (i32.const 3555)
         )
      )"
+  , "(module
+        (func (export \"main\") (result i32)
+          (i32.sub (i32.const 40) (i32.const 2))
+        )
+    )"
+  , "(module
+        (func (export \"main\") (result i32)
+          (i32.const 40)
+          (i32.const 2)
+          (i32.sub)
+        )
+    )"
   ]
 
 def modsControl :=
@@ -64,6 +76,62 @@ def modsControl :=
         )
         (func (export \"main\") (result i32) (call $midvalues))
      )"
+  , "(module
+        (func (export \"main\") (result i32)
+          (block (result i32)
+            (br_if 0
+              (block (result i32) (i32.const 1))
+              (i32.const 2)
+            )
+          )
+        )
+      )"
+  , "(module
+        (func (export \"main\") (result i32)
+          (block (result i32)
+            (br_if 0
+              (i32.const 2)
+              (block (result i32) (i32.const 1))
+            )
+          )
+        )
+      )"
+  , "(module
+        (func $as-select-first (result i32)
+          (select
+            (block (result i32) (i32.const 1))
+            (i32.const 2)
+            (i32.const 3)
+          )
+        )
+        (func (export \"main\") (result i32)
+          (call $as-select-first)
+        )
+      )"
+  , "(module
+        (func $as-select-mid (result i32)
+          (select
+            (i32.const 2)
+            (block (result i32) (i32.const 1))
+            (i32.const 3)
+          )
+        )
+        (func (export \"main\") (result i32)
+          (call $as-select-mid)
+        )
+      )"
+  , "(module
+        (func $as-select-last (result i32)
+          (select
+            (i32.const 2)
+            (i32.const 3)
+            (block (result i32) (i32.const 1))
+          )
+        )
+        (func (export \"main\") (result i32)
+          (call $as-select-last)
+        )
+      )"
   ]
 
 def main : IO UInt32 := do

--- a/Wasm/Wast/AST.lean
+++ b/Wasm/Wast/AST.lean
@@ -130,164 +130,131 @@ end Instruction
 
 namespace Operation
 
-mutual
-  -- Sadge
-  inductive Get' where
-  | from_stack
-  | from_operation : Operation → Get'
-
 -- TODO: add support for function type indexes for blocktypes
 -- TODO: branching ops can produce and consume operands themselves,
 -- e.g. `(br 0 (i32.const 2))`. Right now we don't support it, but should we?
 -- TODO: replace `NumUniT` with something supporting `ConstVec` when implemented
 -- TODO: generalise Consts the same way Get is generalised so that `i32.const`
 -- can't be populated with `ConstFloat`!
-  inductive Operation where
-  | unreachable
-  | nop
-  --------------------- PARAMETRIC ----------------------
-  | drop
-  | select : Option Type' → Get' → Get' → Get' → Operation
-  ----------------------  NUMERIC -----------------------
-  | const : Type' → NumUniT → Operation
-  | eqz : Type' → Get' → Operation
-  | eq  : Type' → Get' → Get' → Operation
-  | ne  : Type' → Get' → Get' → Operation
-  | lt_u  : Type' → Get' → Get' → Operation
-  | lt_s  : Type' → Get' → Get' → Operation
-  | gt_u  : Type' → Get' → Get' → Operation
-  | gt_s  : Type' → Get' → Get' → Operation
-  | le_u  : Type' → Get' → Get' → Operation
-  | le_s  : Type' → Get' → Get' → Operation
-  | ge_u  : Type' → Get' → Get' → Operation
-  | ge_s  : Type' → Get' → Get' → Operation
-  | lt  : Type' → Get' → Get' → Operation
-  | gt  : Type' → Get' → Get' → Operation
-  | le  : Type' → Get' → Get' → Operation
-  | ge  : Type' → Get' → Get' → Operation
-  | clz : Type' → Get' → Operation
-  | ctz : Type' → Get' → Operation
-  | popcnt : Type' → Get' → Operation
-  | add : Type' → Get' → Get' → Operation
-  | sub : Type' → Get' → Get' → Operation
-  | mul : Type' → Get' → Get' → Operation
-  | div : Type' → Get' → Get' → Operation
-  | max : Type' → Get' → Get' → Operation
-  | min : Type' → Get' → Get' → Operation
-  | div_s : Type' → Get' → Get' → Operation
-  | div_u : Type' → Get' → Get' → Operation
-  | rem_s : Type' → Get' → Get' → Operation
-  | rem_u : Type' → Get' → Get' → Operation
-  | and : Type' → Get' → Get' → Operation
-  | or : Type' → Get' → Get' → Operation
-  | xor : Type' → Get' → Get' → Operation
-  | shl : Type' → Get' → Get' → Operation
-  | shr_u : Type' → Get' → Get' → Operation
-  | shr_s : Type' → Get' → Get' → Operation
-  | rotl : Type' → Get' → Get' → Operation
-  | rotr : Type' → Get' → Get' → Operation
-  ---------------------- VARIABLE -----------------------
-  | local_get : LocalLabel → Operation
-  | local_set : LocalLabel → Operation
-  | local_tee : LocalLabel → Operation
-  | global_get : GlobalLabel → Operation
-  | global_set : GlobalLabel → Operation
-  ----------------------- CONTROL -----------------------
-  | block : Option String → List Local → List Type' → List Operation → Operation
-  | loop : Option String → List Local → List Type' → List Operation → Operation
-  | if : Option String → List Local → List Type' → Get'
-            → List Operation → List Operation → Operation
-  | br : BlockLabelId → Operation
-  | br_if : BlockLabelId → Operation
-  | br_table : List BlockLabelId → BlockLabelId → Operation
-  | call : FuncId → Operation
-  | return : Operation
-end
+inductive Operation where
+| unreachable
+| nop
+--------------------- PARAMETRIC ----------------------
+| drop
+| select : Option Type' → Operation
+----------------------  NUMERIC -----------------------
+| const : Type' → NumUniT → Operation
+| eqz : Type' → Operation
+| eq  : Type' → Operation
+| ne  : Type' → Operation
+| lt_u  : Type' → Operation
+| lt_s  : Type' → Operation
+| gt_u  : Type' → Operation
+| gt_s  : Type' → Operation
+| le_u  : Type' → Operation
+| le_s  : Type' → Operation
+| ge_u  : Type' → Operation
+| ge_s  : Type' → Operation
+| lt  : Type' → Operation
+| gt  : Type' → Operation
+| le  : Type' → Operation
+| ge  : Type' → Operation
+| clz : Type' → Operation
+| ctz : Type' → Operation
+| popcnt : Type' → Operation
+| add : Type' → Operation
+| sub : Type' → Operation
+| mul : Type' → Operation
+| div : Type' → Operation
+| max : Type' → Operation
+| min : Type' → Operation
+| div_s : Type' → Operation
+| div_u : Type' → Operation
+| rem_s : Type' → Operation
+| rem_u : Type' → Operation
+| and : Type' → Operation
+| or : Type' → Operation
+| xor : Type' → Operation
+| shl : Type' → Operation
+| shr_u : Type' → Operation
+| shr_s : Type' → Operation
+| rotl : Type' → Operation
+| rotr : Type' → Operation
+---------------------- VARIABLE -----------------------
+| local_get : LocalLabel → Operation
+| local_set : LocalLabel → Operation
+| local_tee : LocalLabel → Operation
+| global_get : GlobalLabel → Operation
+| global_set : GlobalLabel → Operation
+----------------------- CONTROL -----------------------
+| block : Option String → List Local → List Type' → List Operation → Operation
+| loop : Option String → List Local → List Type' → List Operation → Operation
+| if : Option String → List Local → List Type'
+          → List Operation → List Operation → Operation
+| br : BlockLabelId → Operation
+| br_if : BlockLabelId → Operation
+| br_table : List BlockLabelId → BlockLabelId → Operation
+| call : FuncId → Operation
+| return : Operation
 
-mutual
-  private partial def getToString : Get' → String
-    | .from_stack => "(Get'.from_stack)"
-    | .from_operation o => s!"(Get'.from_operation {operationToString o})"
-
-  private partial def operationToString : Operation → String
-    | .unreachable => "(Operation.unreachable)"
-    | .nop => "(Operation.nop)"
-    | .drop => "(Operation.drop)"
-    | .select t g1 g2 g3 => s!"(Operation.select {t} {getToString g1} {getToString g2} {getToString g3})"
-    | .const t n => s!"(Operation.const {t} {n})"
-    | .eqz t g => s!"(Operation.eqz {t} {getToString g})"
-    | .eq  t g1 g2 => s!"(Operation.eq {t} {getToString g1} {getToString g2})"
-    | .ne  t g1 g2 => s!"(Operation.ne {t} {getToString g1} {getToString g2})"
-    | .lt_u t g1 g2 =>
-      s!"(Operation.lt_u {t} {getToString g1} {getToString g2})"
-    | .lt_s t g1 g2 =>
-      s!"(Operation.lt_s {t} {getToString g1} {getToString g2})"
-    | .gt_u t g1 g2 =>
-      s!"(Operation.gt_u {t} {getToString g1} {getToString g2})"
-    | .gt_s t g1 g2 =>
-      s!"(Operation.gt_s {t} {getToString g1} {getToString g2})"
-    | .le_u t g1 g2 =>
-      s!"(Operation.le_u {t} {getToString g1} {getToString g2})"
-    | .le_s t g1 g2 =>
-      s!"(Operation.le_s {t} {getToString g1} {getToString g2})"
-    | .ge_u t g1 g2 =>
-      s!"(Operation.ge_u {t} {getToString g1} {getToString g2})"
-    | .ge_s t g1 g2 =>
-      s!"(Operation.ge_s {t} {getToString g1} {getToString g2})"
-    | .lt  t g1 g2 => s!"(Operation.lt {t} {getToString g1} {getToString g2})"
-    | .gt  t g1 g2 => s!"(Operation.gt {t} {getToString g1} {getToString g2})"
-    | .le  t g1 g2 => s!"(Operation.le {t} {getToString g1} {getToString g2})"
-    | .ge  t g1 g2 => s!"(Operation.ge {t} {getToString g1} {getToString g2})"
-    | .clz t g => s!"(Operation.clz {t} {getToString g})"
-    | .ctz t g => s!"(Operation.ctz {t} {getToString g})"
-    | .popcnt t g => s!"(Operation.popcnt {t} {getToString g})"
-    | .add t g1 g2 => s!"(Operation.add {t} {getToString g1} {getToString g2})"
-    | .sub t g1 g2 => s!"(Operation.sub {t} {getToString g1} {getToString g2})"
-    | .mul t g1 g2 => s!"(Operation.mul {t} {getToString g1} {getToString g2})"
-    | .div t g1 g2 => s!"(Operation.div {t} {getToString g1} {getToString g2})"
-    | .max t g1 g2 => s!"(Operation.max {t} {getToString g1} {getToString g2})"
-    | .min t g1 g2 => s!"(Operation.min {t} {getToString g1} {getToString g2})"
-    | .div_s t g1 g2 =>
-      s!"(Operation.div_s {t} {getToString g1} {getToString g2})"
-    | .div_u t g1 g2 =>
-      s!"(Operation.div_u {t} {getToString g1} {getToString g2})"
-    | .rem_s t g1 g2 =>
-      s!"(Operation.rem_s {t} {getToString g1} {getToString g2})"
-    | .rem_u t g1 g2 =>
-      s!"(Operation.rem_u {t} {getToString g1} {getToString g2})"
-    | .and t g1 g2 => s!"(Operation.and {t} {getToString g1} {getToString g2})"
-    | .or t g1 g2 => s!"(Operation.or {t} {getToString g1} {getToString g2})"
-    | .xor t g1 g2 => s!"(Operation.xor {t} {getToString g1} {getToString g2})"
-    | .shl t g1 g2 => s!"(Operation.shl {t} {getToString g1} {getToString g2})"
-    | .shr_u t g1 g2 =>
-      s!"(Operation.shr_u {t} {getToString g1} {getToString g2})"
-    | .shr_s t g1 g2 =>
-      s!"(Operation.shr_s {t} {getToString g1} {getToString g2})"
-    | .rotl t g1 g2 =>
-      s!"(Operation.rotl {t} {getToString g1} {getToString g2})"
-    | .rotr t g1 g2 =>
-      s!"(Operation.rotr {t} {getToString g1} {getToString g2})"
-    | .local_get l => s!"(Operation.local_get {l})"
-    | .local_set l => s!"(Operation.local_set {l})"
-    | .local_tee l => s!"(Operation.local_tee {l})"
-    | .global_get l => s!"(Operation.global_get {l})"
-    | .global_set l => s!"(Operation.global_set {l})"
-    | .block id pts rts is =>
-      s!"(Operation.block {id} {pts} {rts} {is.map operationToString})"
-    | .loop id pts rts is =>
-      s!"(Operation.loop {id} {pts} {rts} {is.map operationToString})"
-    | .if id pts rts g thens elses =>
-      s!"(Operation.if {id} {pts} {rts} {getToString g} {thens.map operationToString} {elses.map operationToString})"
-    | .br sl => s!"(Operation.br {sl})"
-    | .br_if sl => s!"(Operation.br_if {sl})"
-    | .br_table sls sdef => s!"(Operation.br_table {sls} {sdef})"
-    | .call fi => s!"(Operation.call {fi})"
-    | .return => s!"(Operation.return)"
-
-end
-
-instance : ToString Get' where
-  toString := getToString
+private partial def operationToString : Operation → String
+  | .unreachable => "(Operation.unreachable)"
+  | .nop => "(Operation.nop)"
+  | .drop => "(Operation.drop)"
+  | .select t => s!"(Operation.select {t})"
+  | .const t n => s!"(Operation.const {t} {n})"
+  | .eqz t => s!"(Operation.eqz {t})"
+  | .eq  t => s!"(Operation.eq {t})"
+  | .ne  t => s!"(Operation.ne {t})"
+  | .lt_u t => s!"(Operation.lt_u {t})"
+  | .lt_s t => s!"(Operation.lt_s {t})"
+  | .gt_u t => s!"(Operation.gt_u {t})"
+  | .gt_s t => s!"(Operation.gt_s {t})"
+  | .le_u t => s!"(Operation.le_u {t})"
+  | .le_s t => s!"(Operation.le_s {t})"
+  | .ge_u t => s!"(Operation.ge_u {t})"
+  | .ge_s t => s!"(Operation.ge_s {t})"
+  | .lt  t => s!"(Operation.lt {t})"
+  | .gt  t => s!"(Operation.gt {t})"
+  | .le  t => s!"(Operation.le {t})"
+  | .ge  t => s!"(Operation.ge {t})"
+  | .clz t => s!"(Operation.clz {t})"
+  | .ctz t => s!"(Operation.ctz {t})"
+  | .popcnt t => s!"(Operation.popcnt {t})"
+  | .add t => s!"(Operation.add {t})"
+  | .sub t => s!"(Operation.sub {t})"
+  | .mul t => s!"(Operation.mul {t})"
+  | .div t => s!"(Operation.div {t})"
+  | .max t => s!"(Operation.max {t})"
+  | .min t => s!"(Operation.min {t})"
+  | .div_s t => s!"(Operation.div_s {t})"
+  | .div_u t => s!"(Operation.div_u {t})"
+  | .rem_s t => s!"(Operation.rem_s {t})"
+  | .rem_u t => s!"(Operation.rem_u {t})"
+  | .and t => s!"(Operation.and {t})"
+  | .or t => s!"(Operation.or {t})"
+  | .xor t => s!"(Operation.xor {t})"
+  | .shl t => s!"(Operation.shl {t})"
+  | .shr_u t => s!"(Operation.shr_u {t})"
+  | .shr_s t => s!"(Operation.shr_s {t})"
+  | .rotl t => s!"(Operation.rotl {t})"
+  | .rotr t => s!"(Operation.rotr {t})"
+  | .local_get l => s!"(Operation.local_get {l})"
+  | .local_set l => s!"(Operation.local_set {l})"
+  | .local_tee l => s!"(Operation.local_tee {l})"
+  | .global_get l => s!"(Operation.global_get {l})"
+  | .global_set l => s!"(Operation.global_set {l})"
+  | .block id pts rts is =>
+    s!"(Operation.block {id} {pts} {rts} {is.map operationToString})"
+  | .loop id pts rts is =>
+    s!"(Operation.loop {id} {pts} {rts} {is.map operationToString})"
+  | .if id pts rts thens elses =>
+    s!"(Operation.if {id} {pts} {rts} {thens.map operationToString} {elses.map operationToString})"
+  | .br sl => s!"(Operation.br {sl})"
+  | .br_if sl => s!"(Operation.br_if {sl})"
+  | .br_table sls sdef => s!"(Operation.br_table {sls} {sdef})"
+  | .call fi => s!"(Operation.call {fi})"
+  | .return => s!"(Operation.return)"
 
 instance : ToString Operation where
   toString := operationToString


### PR DESCRIPTION
Problem: once upon a time, we have chosen an architecture/design where we have a predetermined amount of operands for each defined operation, e.g. two operands for `i32.add`, gotten either from the stack or from another "nested" operation. This turns out to be not exactly the greatest design choice, as WA(S)T, in all its glory, allows instructions to be nested completely arbitrarily, including in operations that don't touch the stack themselves. Actually, this is specced as "folded instructions", which is a concept we currently can't support at all.

Solution: removed getters entirely. Now we just follow 6.5.10 of the spec, which postulates that these folded instructions are just unfolded under the hood, putting the "main" intruction after all the "nested" instructions.

Note this makes us lose the original representation at the parsing stage, i.e. we wouldn't be able to round-trip test the pretty-printing, but I'm willing to live with it at this stage.

Also added some tests to RuntimeCompatibility that were used in filing previous issues concerned with this behaviour. Just so I can safely say:

Closes #62, closes #63