### PR TITLE
Support defining and using explicit function types

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -69,21 +69,23 @@ def main : IO Unit := do
   | .ok m => do
     IO.println s!"!!!!!!!!!!!! DEMO OF WASM LEAN RUNTIME WOW !!!!!!!!!!!!!"
     IO.println s!"RUNNING FUNCTION `main` FROM A MODULE WITH REPRESENTATION:\n{m}"
-    let store := mkStore m
-    let ofid := exportedFidByName store "main"
-    let uni_num_zero := NumUniT.i $ ConstInt.mk 32 0
-    let se_zero := StackEntry.StackEntry.num uni_num_zero
-    IO.println $ match ofid with
-    | .none => s!"THERE IS NO FUNCTION CALLED `main`"
-    | .some fid =>
-    ------------- RUNNING HERE --------------
-      let eres := run store fid $ Stack.mk [se_zero, se_zero]
-      match eres with
-      | .ok (_, stack2) => match stack2.es with
-        | [] => "UNEXPECTED RESULT"
-        ---------------- FINALLY GET STACK ENTRIES HERE ----------------
-        | xs => s!"!!!!!!!!!!!!!! SUCCESS !!!!!!!!!!!!!!!!\n{xs}"
-      | .error ee => s!"FAILED TO RUN `main` CORRECTLY: {ee}"
+    match mkStore m with
+    | .error ee => IO.println s!"FAILED TO CONSTRUCT A STORE: {ee}"
+    | .ok store =>
+      let ofid := exportedFidByName store "main"
+      let uni_num_zero := NumUniT.i $ ConstInt.mk 32 0
+      let se_zero := StackEntry.StackEntry.num uni_num_zero
+      IO.println $ match ofid with
+      | .none => s!"THERE IS NO FUNCTION CALLED `main`"
+      | .some fid =>
+      ------------- RUNNING HERE --------------
+        let eres := run store fid $ Stack.mk [se_zero, se_zero]
+        match eres with
+        | .ok (_, stack2) => match stack2.es with
+          | [] => "UNEXPECTED RESULT"
+          ---------------- FINALLY GET STACK ENTRIES HERE ----------------
+          | xs => s!"!!!!!!!!!!!!!! SUCCESS !!!!!!!!!!!!!!!!\n{xs}"
+        | .error ee => s!"FAILED TO RUN `main` CORRECTLY: {ee}"
 
   let mut x := 0
   x := 1

--- a/Tests/BinaryCompatibility.lean
+++ b/Tests/BinaryCompatibility.lean
@@ -490,6 +490,71 @@ def modsNumeric :=
 
   ]
 
+def modsType :=
+[
+  "(module
+      (type (func))
+      (type $t (func))
+  )"
+, "(module
+      (type (func (param i32)))
+      (type (func (param $x i32)))
+      (type (func (result i32)))
+      (type (func (param i32) (result i32)))
+      (type (func (param $x i32) (result i32)))
+  )"
+, "(module
+      (type (func (param f32 f64)))
+      (type (func (result i64 f32)))
+      (type (func (param i32 i64) (result f32 f64)))
+  )"
+, "(module
+      (type (func (param f32) (param f64)))
+      (type (func (param $x f32) (param f64)))
+      (type (func (param f32) (param $y f64)))
+      (type (func (param $x f32) (param $y f64)))
+      (type (func (result i64) (result f32)))
+      (type (func (param i32) (param i64) (result f32) (result f64)))
+      (type (func (param $x i32) (param $y i64) (result f32) (result f64)))
+  )"
+, "(module
+      (type (func (param f32 f64) (param $x i32) (param f64 i32 i32)))
+      (type (func (result i64 i64 f32) (result f32 i32)))
+      (type
+        (func (param i32 i32) (param i64 i32) (result f32 f64) (result f64 i32))
+      )
+  )"
+, "(module
+      (type $t (func (param $x i32)))
+      (func (type $t) (local.get 0) (drop))
+  )"
+, "(module
+      (type $sig-1 (func))
+      (type $sig-2 (func (result i32)))
+      (type $sig-3 (func (param $x i32)))
+      (type $sig-4 (func (param i32 f64 i32) (result i32)))
+
+      (func (export \"type-use-1\") (type $sig-1))
+      (func (export \"type-use-2\") (type $sig-2) (i32.const 0))
+      (func (export \"type-use-3\") (type $sig-3))
+      (func (export \"type-use-4\") (type $sig-4) (i32.const 0))
+  )"
+, "(module
+      (type $sig-1 (func))
+      (type $sig-2 (func (result i32)))
+      (type $sig-3 (func (param $x i32)))
+      (type $sig-4 (func (param i32 f64 i32) (result i32)))
+
+      (func (type $sig-2) (result i32) (i32.const 0))
+      (func (type $sig-3) (param i32))
+      (func (type $sig-4) (param i32) (param f64 i32) (result i32) (i32.const 0))
+  )"
+, "(module
+      (func (type $forward))
+      (type $forward (func))
+  )"
+]
+
 def meaningfulPrograms :=
 [
   "(module
@@ -590,6 +655,6 @@ def meaningfulPrograms :=
 
 def main : IO UInt32 := do
   match (← doesWasmSandboxRun?) with
-  | .ok _ => withWasmSandboxRun moduleTestSeq [ uWasmMods, modsControl, modsLocal, modsGlobal, modsNumeric ]
+  | .ok _ => withWasmSandboxRun moduleTestSeq [ uWasmMods, modsControl, modsLocal, modsGlobal, modsNumeric, modsType ]
   -- TODO: test meaningful programs
   | _ => withWasmSandboxFail

--- a/Tests/SimpleEncodings.lean
+++ b/Tests/SimpleEncodings.lean
@@ -102,26 +102,35 @@ def testIfParses : TestSeq :=
 def testFuncs : TestSeq :=
   let test' := testParse (bracketed funcP)
   group "check that functions parse" $
-    test' "(func)" (Func.mk .none .none [] [] [] []) ++
+    test' "(func)" (Func.mk .none .none (.inr ([],[])) [] []) ++
     test' "(func (param $x i32) (param i32) (result i32))"
       (Func.mk .none .none
-        [(Local.mk (.some "x") (.i 32)), (Local.mk .none (.i 32))]
-        [(.i 32)] [] []
+        (.inr
+          ([(Local.mk (.some "x") (.i 32)), (Local.mk .none (.i 32))]
+          ,[(.i 32)])
+        ) [] []
       ) ++
     test' "(func (param $x i32) (param i32) (result i32) (result i64))"
       (Func.mk .none .none
-        [(Local.mk (.some "x") (.i 32)), (Local.mk .none (.i 32))]
-        [(.i 32), (.i 64)] [] []
+        (.inr
+          ([(Local.mk (.some "x") (.i 32)), (Local.mk .none (.i 32))]
+          ,[(.i 32), (.i 64)])
+        ) [] []
       ) ++
     test' "(func (param $x i32) (param $y i32) (result i32))"
       (Func.mk .none .none
-        [ (Local.mk (.some "x") (.i 32)), (Local.mk (.some "y") (.i 32))]
-        [(.i 32)] [] []
+        (.inr
+          ([ (Local.mk (.some "x") (.i 32)), (Local.mk (.some "y") (.i 32))]
+          ,[(.i 32)])
+        ) [] []
       ) ++
     test' "(func (param $x i32) (param i32) (result i32) (i32.add (i32.const 40) (i32.const 2)))"
     (Func.mk .none .none
-      [(Local.mk (.some "x") (.i 32)), (Local.mk .none (.i 32))]
-      [(.i 32)] []
+      (.inr
+        ([(Local.mk (.some "x") (.i 32)), (Local.mk .none (.i 32))]
+        ,[(.i 32)])
+      )
+      []
       [ .const (.i 32) (.i (ConstInt.mk 32 40))
       , .const (.i 32) (.i (ConstInt.mk 32 2))
       , .add (.i 32)
@@ -144,8 +153,8 @@ def testCommentsIgnored : TestSeq :=
   "
   test "NO PARSE: (func ;; a line comment until eof)"
     (not (parses? (bracketed funcP) "(func ;; a line comment until eof)")) $
-  test' sLine (Func.mk .none .none [] [] [] [.nop]) ++
-  test' sBlock (Func.mk .none .none [] [] [] [.nop])
+  test' sLine (Func.mk .none .none (.inr ([],[])) [] [.nop]) ++
+  test' sBlock (Func.mk .none .none (.inr ([],[])) [] [.nop])
 
 def main : IO UInt32 :=
   lspecIO $

--- a/Wasm/Tests.lean
+++ b/Wasm/Tests.lean
@@ -37,7 +37,7 @@ def run_main (x : String) :=
   run { cmd := "./wasm-sandbox", args := #["run_main", x] } |>.toBaseIO
 
 def runModule (m : Module) : Except EngineErrors Int := do
-  let store := mkStore m
+  let store ← mkStore m
   let s₀ := Stack.mk []
   match exportedFidByName store "main" with
   | .none => .error $ .function_not_found (.by_name "main")

--- a/Wasm/Wast/Code.lean
+++ b/Wasm/Wast/Code.lean
@@ -31,3 +31,8 @@ def defNum : Type' → NumUniT
 
 def replaceNth (xs : List α) (idx : Nat) (x : α) :=
   xs.take idx ++ x :: xs.drop (idx+1)
+
+def fetchFType (fts : List FunctionType)
+              : FunctionType.FTypeId → Option FunctionType
+  | .by_index idx => fts.get? idx
+  | .by_name n => fts.find? (·.tid = .some n)


### PR DESCRIPTION
Problem: as per the spec, the main way to defined functions in wast is actually to use references to an explicitly defined type instead of listing params and results in the function head. We don't currently support that.

Solution: added support both for type definions and usage.